### PR TITLE
Call this.removeTrailingSlash

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -300,7 +300,7 @@ export function ResourceAction(action?: ResourceActionBase) {
 
 				// Remove trailing slash
 				if (typeof action.removeTrailingSlash === "undefined") {
-					action.removeTrailingSlash = this.removeTrailingSlash;
+					action.removeTrailingSlash = this.removeTrailingSlash();
 				}
 				if (action.removeTrailingSlash) {
 					while (url[url.length-1] == '/') {


### PR DESCRIPTION
Set `action.removeTrailingSlash` to the result of the function instead of the function itself, so that `action.removeTrailingSlash` doesn't always evaluate to `true`.