### PR TITLE
Undefined TGetParamsMappingType error

### DIFF
--- a/src/ResourceGlobalConfig.ts
+++ b/src/ResourceGlobalConfig.ts
@@ -1,3 +1,8 @@
+export enum TGetParamsMappingType {
+  Plain,
+  Bracket
+}
+
 export class ResourceGlobalConfig {
   static url: string | Promise<string> = null;
   static path: string | Promise<string> = null;
@@ -9,9 +14,4 @@ export class ResourceGlobalConfig {
   static data: any | Promise<any> = null;
 
   static getParamsMappingType: any = TGetParamsMappingType.Plain;
-}
-
-export enum TGetParamsMappingType {
-  Plain,
-  Bracket
 }


### PR DESCRIPTION
Thanks a lot!
But, I see the error after run the package: 
`ResourceGlobalConfig.ts:11: Uncaught TypeError: Cannot read property 'Plain' of undefined`

Because after compilation the code of config is:
```
export var ResourceGlobalConfig = (function () {
    function ResourceGlobalConfig() {
    }
    ResourceGlobalConfig.url = null;
    ResourceGlobalConfig.path = null;
    ResourceGlobalConfig.headers = {
        'Accept': 'application/json',
        'Content-Type': 'application/json'
    };
    ResourceGlobalConfig.params = null;
    ResourceGlobalConfig.data = null;
    ResourceGlobalConfig.getParamsMappingType = TGetParamsMappingType.Plain;
    return ResourceGlobalConfig;
}());
export var TGetParamsMappingType;
(function (TGetParamsMappingType) {
    TGetParamsMappingType[TGetParamsMappingType["Plain"] = 0] = "Plain";
    TGetParamsMappingType[TGetParamsMappingType["Bracket"] = 1] = "Bracket";
})(TGetParamsMappingType || (TGetParamsMappingType = {}));
```