### PR TITLE
feat(ResourceAction): descriptors for enhanced object

### DIFF
--- a/src/ResourceAction.ts
+++ b/src/ResourceAction.ts
@@ -325,7 +325,19 @@ export function ResourceAction(methodOptions?: ResourceActionBase) {
                           if (!!resourceModel) {
                             (<ResourceModel<Resource>>ret).$fillFromObject(resp);
                           } else {
-                            Object.assign(ret, resp);
+                            let descriptors = Object.keys(resp).reduce((descriptors, key) => {
+                              descriptors[key] = Object.getOwnPropertyDescriptor(resp, key);
+                              return descriptors;
+                            }, {});
+                            
+                            Object.getOwnPropertySymbols(resp).forEach(sym => {
+                              let descriptor = Object.getOwnPropertyDescriptor(resp, sym);
+                              if (descriptor.enumerable) {
+                                descriptors[sym] = descriptor;
+                              }
+                            });
+                            
+                            Object.defineProperties(ret, descriptors);
                           }
                         }
                       }


### PR DESCRIPTION
Instead of juste Object.assign on the return object, use of getOwnPropertyDescriptor to get every descriptors of the received, filtered and mapped object.