### PR TITLE
instantiate model from overridable ressource method

### DIFF
--- a/src/Interfaces.ts
+++ b/src/Interfaces.ts
@@ -21,6 +21,10 @@ export interface ResourceResponseFilter {
   (item: any): boolean;
 }
 
+export interface ResourceResponseInstantiate {
+  (): ResourceResult<any>;
+}
+
 export interface ResourceParamsCommon {
   url?: string;
   path?: string;
@@ -46,6 +50,7 @@ export interface ResourceActionBase extends ResourceParamsCommon {
   responseInterceptor?: ResourceResponseInterceptor;
   map?: ResourceResponseMap;
   filter?: ResourceResponseFilter;
+  instantiate?: ResourceResult<any>;
   model?: Type<ResourceModel<Resource>>;
   useModel?: boolean;
   rootNode?: string;

--- a/src/Resource.ts
+++ b/src/Resource.ts
@@ -5,7 +5,7 @@ import { Observable } from 'rxjs/Rx';
 import { ResourceGlobalConfig } from './ResourceGlobalConfig';
 import { ResourceModel } from './ResourceModel';
 import { ResourceParamsBase } from './Interfaces';
-import { ResourceActionBase } from './Interfaces';
+import { ResourceActionBase, ResourceResult } from './Interfaces';
 
 export class Resource {
 
@@ -131,6 +131,10 @@ export class Resource {
 
   filter(item: any): boolean {
     return true;
+  }
+
+  instantiate(): ResourceResult<any> {
+    return {};
   }
 
   getResourceOptions(): ResourceParamsBase {

--- a/src/ResourceAction.ts
+++ b/src/ResourceAction.ts
@@ -2,7 +2,7 @@ import { Headers, Request, RequestMethod, RequestOptions, Response, URLSearchPar
 import { ConnectableObservable, Observable, Subscriber, Subscription } from 'rxjs/Rx';
 import { ReflectiveInjector } from '@angular/core';
 import { Type } from '@angular/core/src/type';
-import { ResourceActionBase, ResourceResponseFilter, ResourceResponseMap, ResourceResult } from './Interfaces';
+import { ResourceActionBase, ResourceResponseFilter, ResourceResponseMap, ResourceResult, ResourceResponseInstantiate } from './Interfaces';
 import { Resource } from './Resource';
 import { ResourceModel } from './ResourceModel';
 import { ResourceGlobalConfig, TGetParamsMappingType } from './ResourceGlobalConfig';
@@ -35,6 +35,7 @@ export function ResourceAction(methodOptions?: ResourceActionBase) {
 
       let map: ResourceResponseMap = methodOptions.map ? methodOptions.map : this.map;
       let filter: ResourceResponseFilter = methodOptions.filter ? methodOptions.filter : this.filter;
+      let instantiate: ResourceResponseInstantiate = methodOptions.instantiate ?  methodOptions.instantiate : this.instantiate;
 
       if (methodOptions.useModel) {
         if (this.constructor.hasOwnProperty('getResourceModel') && !methodOptions.model) {
@@ -47,9 +48,9 @@ export function ResourceAction(methodOptions?: ResourceActionBase) {
       if (resourceModel && !methodOptions.isArray) {
         ret = resourceModel.create({}, false);
       } else if (methodOptions.isLazy) {
-        ret = {};
+        ret = instantiate();
       } else {
-        ret = methodOptions.isArray ? [] : map(null) || {};
+        ret = methodOptions.isArray ? [] : instantiate();
       }
 
       let mainDeferredSubscriber: Subscriber<any> = null;


### PR DESCRIPTION
Hello,

I look for your solution in this [commit](https://github.com/troyanskiy/ng2-resource-rest/commit/3354552af78753cb1137ddb0e4528d8ffa055061). It doesn't sounds good to me to use the map function for instantiation. First, cause it's not the role of a method called map. Second, cause it force the user of your library to check for null value in the method.

But your solution is the one. Give the user a hook to tell to your library how to build the object. That's why I propose to you this dedicated method of instantiation.

Have a nice day,
Cham